### PR TITLE
changing to raw.githubusercontent.com

### DIFF
--- a/bin/update-arcanist
+++ b/bin/update-arcanist
@@ -1,1 +1,1 @@
-curl -L https://raw.github.com/diablomedia/avt-arcanist/master/getarcanist.sh 2> /dev/null | /bin/sh
+curl -L https://raw.githubusercontent.com/diablomedia/avt-arcanist/master/getarcanist.sh 2> /dev/null | /bin/sh

--- a/getarcanist.sh
+++ b/getarcanist.sh
@@ -3,6 +3,6 @@ set -e
 
 INSTALL_SCRIPT="/tmp/installarcanist.sh"
 
-curl -L https://raw.github.com/diablomedia/avt-arcanist/master/installarcanist.sh -o $INSTALL_SCRIPT
+curl -L https://raw.githubusercontent.com/diablomedia/avt-arcanist/master/installarcanist.sh -o $INSTALL_SCRIPT
 /bin/bash $INSTALL_SCRIPT
 rm $INSTALL_SCRIPT


### PR DESCRIPTION
Ran into 400 bad request error with raw.github.com and CURL (seemed to
be a cert issue, as running curl with -k fixed it)  We don’t want to do
that though, so pointing at raw.githubusercontent.com instead (which is
where raw.github.com redirects to)
