### PR TITLE
add interpreter to arc command; auto-detect optional CONDUIT_TOKEN

### DIFF
--- a/bin/arc
+++ b/bin/arc
@@ -1,0 +1,7 @@
+#!/bin/bash
+if [[ -n "$CONDUIT_TOKEN" ]]
+then
+    /usr/share/php/arcanist/scripts/arcanist.php --load-phutil-library='/usr/share/php/libavt/src' --conduit-token=$CONDUIT_TOKEN "$@"
+else
+    /usr/share/php/arcanist/scripts/arcanist.php --load-phutil-library='/usr/share/php/libavt/src' "$@"
+fi

--- a/installarcanist.sh
+++ b/installarcanist.sh
@@ -59,7 +59,7 @@ ln -fs "$ARC_PHP_DIR/libavt/bin/update-arcanist" "$ARC_BIN_DIR/update-arcanist"
 chmod +x "$ARC_BIN_DIR/update-arcanist"
 
 ## arc
-echo "php $ARC_PHP_DIR/arcanist/scripts/arcanist.php  --load-phutil-library='$ARC_PHP_DIR/libavt/src' \"\$@\"" > "$ARC_BIN_DIR/arc"
+ln -fs "$ARC_PHP_DIR/libavt/bin/arc" "$ARC_BIN_DIR/arc"
 chmod +x "$ARC_BIN_DIR/arc"
 
 echo "Done!"


### PR DESCRIPTION
The #!/bin/bash interpreter is required for this script to run on OSX and as a standalone command within a container.

The CONDUIT_TOKEN detection is simply a convenience for being able to run this easily inside of a container.