### PR TITLE
remove --load-phutil-library CLI arg, modernize a .arcconfig setting

### DIFF
--- a/bin/arc
+++ b/bin/arc
@@ -1,7 +1,7 @@
 #!/bin/bash
 if [[ -n "$CONDUIT_TOKEN" ]]
 then
-    /usr/share/php/arcanist/scripts/arcanist.php --load-phutil-library='/usr/share/php/libavt/src' --conduit-token=$CONDUIT_TOKEN "$@"
+    /usr/share/php/arcanist/scripts/arcanist.php --conduit-token=$CONDUIT_TOKEN "$@"
 else
-    /usr/share/php/arcanist/scripts/arcanist.php --load-phutil-library='/usr/share/php/libavt/src' "$@"
+    /usr/share/php/arcanist/scripts/arcanist.php "$@"
 fi

--- a/bin/create-arcconfig
+++ b/bin/create-arcconfig
@@ -38,9 +38,9 @@ echo "Creating default .arcconfig at '$arc_path'"
     "lint.phpcs.standard": "build/phpcs.xml",
     "unit.engine": "AvtPhpunitTestEngine",
     "phpunit_config": "build/phpunit.xml",
-    "phutil_libraries" : {
-        "avt" : "$libavt_path"
-    }
+    "load": [
+        "$libavt_path"
+    ]
 }
 EOT
 } > $arc_path


### PR DESCRIPTION
The `--load-phutil-library` CLI arg was overriding any attempt to add additional libraries to the .arcconfig load paths. This change does require that .arcconfig (or global variants) include the libavt path, but the create-arcconfig script was already doing that anyway.