### PR TITLE
Using `bin/arc` instead of `scripts/arcanist.php` for arc, not installing libphutil

### DIFF
--- a/bin/arc
+++ b/bin/arc
@@ -1,7 +1,7 @@
 #!/bin/bash
 if [[ -n "$CONDUIT_TOKEN" ]]
 then
-    /usr/share/php/arcanist/scripts/arcanist.php --conduit-token=$CONDUIT_TOKEN "$@"
+    /usr/share/php/arcanist/bin/arc --conduit-token=$CONDUIT_TOKEN "$@"
 else
-    /usr/share/php/arcanist/scripts/arcanist.php "$@"
+    /usr/share/php/arcanist/bin/arc "$@"
 fi

--- a/installarcanist.sh
+++ b/installarcanist.sh
@@ -29,14 +29,12 @@ if [ ! -e "$ARC_PHP_DIR" ]; then
     mkdir -p $ARC_PHP_DIR
 fi;
 
-# Install or update libphutil
-echo "Updating libphutil.."
-if [ -e "$ARC_PHP_DIR/libphutil" ]; then
+# Install or update arcanist
+echo "Updating arcanist.."
+if [ -e "$ARC_PHP_DIR/arcanist" ]; then
     $ARC_BIN_DIR/arc upgrade
 else
-    git clone git://github.com/facebook/libphutil.git "$ARC_PHP_DIR/libphutil"
-    git clone git://github.com/facebook/arcanist.git "$ARC_PHP_DIR/arcanist"
-    #git clone git://github.com/facebook/phabricator.git "$ARC_PHP_DIR/phabricator"
+    git clone git://github.com/phacility/arcanist.git "$ARC_PHP_DIR/arcanist"
 fi
 
 # Install or update libavt


### PR DESCRIPTION
`scripts/arcanist.php` doesn't seem to work very well now as the phacility team is modernizing the arc workflow (specifically this change broke `arc land` for us: https://secure.phabricator.com/D21315#change-0W5UuDlpN3Dk). Using `bin/arc` which seems to resolve this.

Also no longer installing `libphutil` since that's no longer necessary (comes bundled in `arcanist` now).

Fixing redirected github URLs.